### PR TITLE
Adding DNS-01 option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 Based on https://github.com/nginx-proxy/nginx-proxy
 
-A new env varaible `ENABLE_ACME` is added to use acme.sh to generate free ssl cert from letsencrypt.
+A few new env variables are added to use acme.sh to generate free ssl cert from letsencrypt.
+- `ENABLE_ACME` => Set to `true` on other containers to enable certificate generation
+- `ACME_DNS` => Set to `true` on this container to enable DNS-01 challenge
+- `DNS_HOOK` => Set to one of the DNS hook script from the acme.sh script. This also adds the various environment variables used by the hook script specified. ie: `AD_API_KEY` for the dns_ad hook.
+
 
 All the other options are the same as the upstream project.
 It's very easy to use:

--- a/updatessl.sh
+++ b/updatessl.sh
@@ -3,6 +3,10 @@
 _SCRIPT_="$0"
 
 ACME_BIN="/acme.sh/acme.sh --home /acme.sh --config-home /acmecerts"
+if test "$ACME_DNS" = 'true' ; then
+  echo "enabling dns mode"
+  ACME_BIN="$ACME_BIN --dns $DNS_HOOK"
+fi
 
 DEFAULT_CONF="/etc/nginx/conf.d/default.conf"
 


### PR DESCRIPTION
I noticed the updatessl script didn't have any option to use DNS hooks from the acme.sh script and I needed this for my internal websites. Let me know of any required change to be made before merge if you feel this is a good added value to your container. :smiley: 