### PR TITLE
Remove deprecated OCSP Must-Staple extension

### DIFF
--- a/updatessl.sh
+++ b/updatessl.sh
@@ -16,7 +16,7 @@ updatessl() {
     for d_list in $(grep ACME_DOMAINS $DEFAULT_CONF | cut -d ' ' -f 2);
     do
       d=$(echo "$d_list" | cut -d , -f 1)
-      $ACME_BIN --issue --server letsencrypt --ocsp -k ec-256 \
+      $ACME_BIN --issue --server letsencrypt -k ec-256 \
       -d $d_list \
       --nginx \
       --fullchain-file "$CERTS/$d.crt" \


### PR DESCRIPTION
Since January 30, 2025 OCSP Must-Staple requests will fail, unless the requesting account has previously issued a certificate containing the OCSP Must Staple extension: 
https://letsencrypt.org/2024/12/05/ending-ocsp/

Currently running `/app/updatessl.sh` resolves in:
```log
[Wed Apr 30 12:30:04 UTC 2025] Verification finished, beginning signing.
[Wed Apr 30 12:30:04 UTC 2025] Let's finalize the order.
[Wed Apr 30 12:30:04 UTC 2025] Le_OrderFinalize='https://acme-v02.api.letsencrypt.org/acme/finalize/***/***'
[Wed Apr 30 12:30:05 UTC 2025] Signing failed. Finalize code was not 200.
[Wed Apr 30 12:30:05 UTC 2025] {
  "type": "urn:ietf:params:acme:error:unauthorized",
  "detail": "Error finalizing order :: OCSP must-staple extension is no longer available: see https://letsencrypt.org/2024/12/05/ending-ocsp",
  "status": 403
}  
```