### PR TITLE
ci: also push images to ghcr.io

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   multiarch-build-debian:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
 
       - name: Checkout
@@ -21,6 +24,7 @@ jobs:
         with:
           images: |
             neilpang/letsproxy
+            ghcr.io/${{ github.repository_owner }}/letsproxy
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
             type=ref,event=branch
@@ -37,6 +41,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push the Debian based image
         id: docker_build_debian
         uses: docker/build-push-action@v6
@@ -52,6 +63,9 @@ jobs:
 
   multiarch-build-alpine:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
 
       - name: Checkout
@@ -65,6 +79,7 @@ jobs:
         with:
           images: |
             neilpang/letsproxy
+            ghcr.io/${{ github.repository_owner }}/letsproxy
           tags: |
             type=raw,value=alpine,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
             type=ref,suffix=-alpine,event=branch
@@ -81,6 +96,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push the Alpine based image
         id: docker_build_alpine


### PR DESCRIPTION
Publish each build to GitHub Container Registry alongside Docker Hub, so users can pull from ghcr.io/neilpang/letsproxy as well.